### PR TITLE
explicit bind socket function

### DIFF
--- a/unit_test/UDPSocket.cpp
+++ b/unit_test/UDPSocket.cpp
@@ -103,7 +103,7 @@ void CSocket::BindLocalPort( unsigned short localPort ) throw(CSocketException)
     localAddr.sin_addr.s_addr = htonl(INADDR_ANY);
     localAddr.sin_port = htons(localPort);
 
-    if (bind(m_sockDesc, (sockaddr *) &localAddr, sizeof(sockaddr_in)) < 0) {
+    if (::bind(m_sockDesc, (sockaddr *) &localAddr, sizeof(sockaddr_in)) < 0) {
         throw CSocketException("Set of local port failed (bind())", true);
     }
 }
@@ -115,7 +115,7 @@ void CSocket::BindLocalAddressAndPort( const string &localAddress, unsigned shor
     sockaddr_in localAddr;
     FillAddr(localAddress, localPort, localAddr);
 
-    if (bind(m_sockDesc, (sockaddr *) &localAddr, sizeof(sockaddr_in)) < 0) {
+    if (::bind(m_sockDesc, (sockaddr *) &localAddr, sizeof(sockaddr_in)) < 0) {
         throw CSocketException("Set of local address and port failed (bind())", true);
     }
 }


### PR DESCRIPTION
avoid the following error arised by clang

 error: invalid operands to binary expression ('__bind<int &,
 sockaddr *, unsigned long>' and 'int')